### PR TITLE
Supprimer les signatures des PJ lors de la fusion

### DIFF
--- a/src/main/java/fr/univlorraine/ecandidat/controllers/CandidatureController.java
+++ b/src/main/java/fr/univlorraine/ecandidat/controllers/CandidatureController.java
@@ -103,6 +103,7 @@ import fr.univlorraine.ecandidat.utils.ListenerUtils.CandidatureListener;
 import fr.univlorraine.ecandidat.utils.ListenerUtils.OdfListener;
 import fr.univlorraine.ecandidat.utils.MethodUtils;
 import fr.univlorraine.ecandidat.utils.NomenclatureUtils;
+import fr.univlorraine.ecandidat.utils.PDFMergerUtilityEx;
 import fr.univlorraine.ecandidat.utils.bean.export.ExportDossierAvis;
 import fr.univlorraine.ecandidat.utils.bean.export.ExportDossierBac;
 import fr.univlorraine.ecandidat.utils.bean.export.ExportDossierCandidat;
@@ -1675,7 +1676,7 @@ public class CandidatureController {
 		InputStream is = null;
 		try {
 			/* Merger */
-			final PDFMergerUtility ut = new PDFMergerUtility();
+			final PDFMergerUtility ut = new PDFMergerUtilityEx();
 
 			/* Propriétés du document */
 			final PDDocumentInformation info = new PDDocumentInformation();

--- a/src/main/java/fr/univlorraine/ecandidat/utils/PDFMergerUtilityEx.java
+++ b/src/main/java/fr/univlorraine/ecandidat/utils/PDFMergerUtilityEx.java
@@ -1,0 +1,114 @@
+/**
+ *  ESUP-Portail eCandidat - Copyright (c) 2016 ESUP-Portail consortium
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package fr.univlorraine.ecandidat.utils;
+
+import java.io.IOException;
+import org.apache.pdfbox.cos.COSArray;
+import org.apache.pdfbox.cos.COSBase;
+import org.apache.pdfbox.cos.COSDictionary;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.cos.COSObject;
+import org.apache.pdfbox.multipdf.PDFMergerUtility;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.interactive.form.PDAcroForm;
+
+/**
+ *
+ * @author vriviere
+ */
+public class PDFMergerUtilityEx extends PDFMergerUtility {
+
+    private static void removeAllDigitalSignatures(PDDocument doc) {
+        COSDictionary catalogDict = doc.getDocumentCatalog().getCOSObject();
+        catalogDict.removeItem(COSName.PERMS);
+        catalogDict.removeItem(COSName.getPDFName("DSS"));
+    }
+
+    private static void removeAllSignatureFields(PDDocument doc) {
+        PDAcroForm acroForm = doc.getDocumentCatalog().getAcroForm(null);
+        if (acroForm == null)
+            return;
+
+        COSArray arrayFields = acroForm.getCOSObject().getCOSArray(COSName.FIELDS);
+        if (arrayFields == null)
+            return;
+
+        for (var iter = arrayFields.iterator(); iter.hasNext(); ) {
+            COSBase baseRefField = iter.next();
+            if (!(baseRefField instanceof COSObject))
+                continue;
+            COSObject objRefField = (COSObject)baseRefField;
+
+            COSBase baseField = objRefField.getObject();
+            if (!(baseField instanceof COSDictionary))
+                continue;
+            COSDictionary objField = (COSDictionary)baseField;
+
+            COSName fieldType = objField.getCOSName(COSName.FT);
+            if (fieldType != null && fieldType.equals(COSName.SIG))
+                iter.remove();
+        }
+    }
+
+    private static void removeAllVisibleSignatures(PDDocument doc) {
+        for (PDPage page : doc.getPages()) {
+            COSBase baseAnnotations = page.getCOSObject().getDictionaryObject(COSName.ANNOTS);
+            if (!(baseAnnotations instanceof COSArray))
+                continue;
+            COSArray arrayAnnotations = (COSArray)baseAnnotations;
+
+            for (var iter = arrayAnnotations.iterator(); iter.hasNext(); ) {
+                COSBase baseRefAnnotation = iter.next();
+                if (!(baseRefAnnotation instanceof COSObject))
+                    continue;
+
+                COSObject objRefAnnotation = (COSObject)baseRefAnnotation;
+                COSBase baseAnnotation = objRefAnnotation.getObject();
+                if (!(baseAnnotation instanceof COSDictionary))
+                    continue;
+
+                COSDictionary dictAnnotation = (COSDictionary)baseAnnotation;
+                COSName fieldType = dictAnnotation.getCOSName(COSName.FT);
+                if (fieldType != null && fieldType.equals(COSName.SIG))
+                    iter.remove();
+            }
+        }
+    }
+
+    private static void removeSigFlags(PDDocument doc) {
+        PDAcroForm acroForm = doc.getDocumentCatalog().getAcroForm(null);
+        if (acroForm == null)
+            return;
+
+        acroForm.getCOSObject().removeItem(COSName.SIG_FLAGS);
+    }
+
+    public static void removeAllSignatures(PDDocument doc) {
+        doc.setAllSecurityToBeRemoved(true);
+        removeAllDigitalSignatures(doc);
+        removeAllSignatureFields(doc);
+        removeAllVisibleSignatures(doc);
+        removeSigFlags(doc);
+    }
+
+    @Override
+    public void appendDocument(PDDocument destination, PDDocument source) throws IOException {
+        removeAllSignatures(source);
+        super.appendDocument(destination, source);
+    }
+}


### PR DESCRIPTION
Je propose ce patch pour corriger l'issue #56. C'est en PROD à Paris 1 depuis quelques semaines, et cela nous donne satisfaction.
Je souhaite qu'il soit intégré (sous une forme ou une autre) à la version officielle d'eCandidat.

Point clé :
Depuis quelques mois, les relevés de notes de l'Université Paris 1 sont signés numériquement. Lorsque des candidats issus de Paris 1 vont candidater sur les applications eCandidat des autres établissements, ils vont déposer leurs relevés de notes dans les PJ. Comme ils sont signés, lors de la fusion avec les autres pages du dossier eCandidat, la signature va devenir invalide.  Nous ne souhaitons pas que les dossiers des étudiants Paris 1 se retrouvent invalides dans les autres établissements.

Ce patch supprime les signatures des documents fusionnés. Ainsi, le dossier eCandidat fusionné ne contiendra jamais de bribes de signatures invalides. Si les établissements n'ont pas activé la signature numérique dans eCandidat, le dossier restera non signé, mais valide.

NB : Concernant la forme, je n'ai pas fait d'effort particulier, car je ne sais pas si ce patch va être mergé tel quel. Bien sûr, si besoin, je suis prêt à le raffiner avec des commentaires, etc. Mais peut-être que ce patch ne sera pas utilisé tel quel, et servira juste de source d'inspiration pour l'intégration officielle. Tout ce que je souhaite, c'est que cette fonctionnalité soit intégrée dans la version officielle, d'une manière ou d'une autre.